### PR TITLE
Fix focus highlight color in suggestion lists

### DIFF
--- a/themes/hop-light.tmTheme
+++ b/themes/hop-light.tmTheme
@@ -21,6 +21,10 @@
                 <string>#F5F5F5</string>
                 <key>selection</key>
                 <string>#C2E8F4</string>
+                <key>editorSuggestWidget.focusHighlightForeground</key>
+                <string>#D4E0FF</string>
+                <key>list.focusHighlightForeground</key>
+                <string>#D4E0FF</string>
             </dict>
         </dict>
         <dict>

--- a/themes/hop-light.tmTheme
+++ b/themes/hop-light.tmTheme
@@ -22,9 +22,9 @@
                 <key>selection</key>
                 <string>#C2E8F4</string>
                 <key>editorSuggestWidget.focusHighlightForeground</key>
-                <string>#D4E0FF</string>
+                <string>#5ADEFF</string>
                 <key>list.focusHighlightForeground</key>
-                <string>#D4E0FF</string>
+                <string>#5ADEFF</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
I took the liberty of adding a light shade of blue to the focus color as I found it easier to discern than just white bold but I'm no graphic designer!

Fixes https://github.com/bubersson/hop-theme-vscode/issues/1